### PR TITLE
feat: [HZN-6681] - Redirect traffic from https://www.himgs.com / to https://www.hola.com/ and adjustments in Akamai.

### DIFF
--- a/apache-redirects/latest/Dockerfile
+++ b/apache-redirects/latest/Dockerfile
@@ -14,6 +14,8 @@ RUN mkdir -p /var/www/hola-images
 RUN mkdir -p /var/www/hola-us
 RUN mkdir -p /var/www/hola-fashionweek
 RUN mkdir -p /var/www/hola
+RUN mkdir -p /var/www/quiosco-static
+RUN mkdir -p /var/www/himgs
 
 
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf
@@ -43,5 +45,6 @@ COPY hello-origin/* /var/www/hello-origin/
 COPY hola-fashionweek/* /var/www/hola-fashionweek/
 COPY hola/* /var/www/hola/
 COPY quiosco-static/* /var/www/quiosco-static/
+COPY himgs/* /var/www/himgs/
 
 EXPOSE 80

--- a/apache-redirects/latest/himgs/.htaccess
+++ b/apache-redirects/latest/himgs/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^(www\.)?himgs\.com$ [NC]
+RewriteRule ^(.*)$ https://www.hola.com/$1 [L,R=301]

--- a/apache-redirects/latest/httpd-vhosts.conf
+++ b/apache-redirects/latest/httpd-vhosts.conf
@@ -92,3 +92,13 @@
     DocumentRoot "/var/www/quiosco-static"
     ServerName quiosco-static.hola.com
 </VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/himgs"
+    ServerName himgs.com
+</VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/himgs"
+    ServerName www.himgs.com
+</VirtualHost>


### PR DESCRIPTION
This pull request introduces updates to the `apache-redirects` project to support two new directories, `quiosco-static` and `himgs`, including their integration into the Apache configuration and related files. The changes ensure proper handling of requests for these directories and add a rewrite rule for `himgs.com`.

### Additions to support new directories:

* [`apache-redirects/latest/Dockerfile`](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R17-R18): Added commands to create directories `/var/www/quiosco-static` and `/var/www/himgs` and copy their respective contents into the container. [[1]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R17-R18) [[2]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R48)

### Apache configuration updates:

* [`apache-redirects/latest/httpd-vhosts.conf`](diffhunk://#diff-7ccc1eb2b0389cfa78f0e8aa8e02a23a9733706fc58676c68005fc6a7fca35a4R95-R99): Added a new `<VirtualHost>` block for `himgs.com`, setting its `DocumentRoot` to `/var/www/himgs`.

### Rewrite rule for `himgs.com`:

* [`apache-redirects/latest/himgs/.htaccess`](diffhunk://#diff-4734297710a04dd97c7a6350fd09d88d801d5f09eb929d2eb471d7986fd61819R1-R3): Added a rewrite rule to redirect all traffic from `himgs.com` to `https://www.hola.com`.