### PR TITLE
feat: [HZN-6681] - Redirect traffic from https://www.himgs.com / to https://www.hola.com/ and adjustments in Akamai.

### DIFF
--- a/apache-redirects/latest/Dockerfile
+++ b/apache-redirects/latest/Dockerfile
@@ -14,6 +14,8 @@ RUN mkdir -p /var/www/hola-images
 RUN mkdir -p /var/www/hola-us
 RUN mkdir -p /var/www/hola-fashionweek
 RUN mkdir -p /var/www/hola
+RUN mkdir -p /var/www/quiosco-static
+RUN mkdir -p /var/www/himgs
 
 
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf
@@ -43,5 +45,6 @@ COPY hello-origin/* /var/www/hello-origin/
 COPY hola-fashionweek/* /var/www/hola-fashionweek/
 COPY hola/* /var/www/hola/
 COPY quiosco-static/* /var/www/quiosco-static/
+COPY himgs/* /var/www/himgs/
 
 EXPOSE 80

--- a/apache-redirects/latest/himgs/.htaccess
+++ b/apache-redirects/latest/himgs/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^(www\.)?himgs\.com$ [NC]
+RewriteRule ^(.*)$ https://www.hola.com/$1 [L,R=301]

--- a/apache-redirects/latest/httpd-vhosts.conf
+++ b/apache-redirects/latest/httpd-vhosts.conf
@@ -92,3 +92,13 @@
     DocumentRoot "/var/www/quiosco-static"
     ServerName quiosco-static.hola.com
 </VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/himgs"
+    ServerName himgs.com
+</VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/himgs"
+    ServerName www.himgs.com
+</VirtualHost>


### PR DESCRIPTION
This pull request introduces changes to add support for a new `himgs` subdomain and updates configurations for static content handling in the Apache server setup. The most important changes include creating directories for `himgs`, copying its content, adding rewrite rules for redirection, and updating virtual host configurations.

### Additions for `himgs` subdomain:

* [`apache-redirects/latest/Dockerfile`](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R17-R18): Added commands to create the `/var/www/himgs` directory and copy content from the `himgs` source folder. [[1]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R17-R18) [[2]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R48)
* [`apache-redirects/latest/himgs/.htaccess`](diffhunk://#diff-4734297710a04dd97c7a6350fd09d88d801d5f09eb929d2eb471d7986fd61819R1-R3): Introduced rewrite rules to redirect requests from `himgs.com` and `www.himgs.com` to `www.hola.com` with a 301 status code.
* [`apache-redirects/latest/httpd-vhosts.conf`](diffhunk://#diff-7ccc1eb2b0389cfa78f0e8aa8e02a23a9733706fc58676c68005fc6a7fca35a4R95-R104): Added virtual host configurations for `himgs.com` and `www.himgs.com` to serve content from `/var/www/himgs`.