### PR TITLE
feat: [HZN-8311] - Revert image subdomain hosting to images.hellomaga…

### DIFF
--- a/apache-redirects/latest/Dockerfile
+++ b/apache-redirects/latest/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /var/www/hola-fashionweek
 RUN mkdir -p /var/www/hola
 RUN mkdir -p /var/www/quiosco-static
 RUN mkdir -p /var/www/himgs
+RUN mkdir -p /var/www/hello-58v76y8z87lo
 
 
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf
@@ -29,6 +30,7 @@ COPY index.html /var/www/hola-ca/
 COPY index.html /var/www/hola-mx/
 COPY index.html /var/www/hola-premiosgoya/
 COPY index.html /var/www/hola-images/
+COPY index.html /var/www/hello-58v76y8z87lo
 
 COPY hello-us/* /var/www/hello-us/
 COPY hello-ca/* /var/www/hello-ca/
@@ -46,5 +48,6 @@ COPY hola-fashionweek/* /var/www/hola-fashionweek/
 COPY hola/* /var/www/hola/
 COPY quiosco-static/* /var/www/quiosco-static/
 COPY himgs/* /var/www/himgs/
+COPY hello-58v76y8z87lo/* /var/www/hello-58v76y8z87lo/
 
 EXPOSE 80

--- a/apache-redirects/latest/hello-58v76y8z87lo/.htaccess
+++ b/apache-redirects/latest/hello-58v76y8z87lo/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+
+RewriteCond %{HTTP_HOST} ^58v76y8z87lo\.hellomagazine\.com$ [NC]
+RewriteRule ^(.*)$ https://images.hellomagazine.com/$1 [R=301,L]

--- a/apache-redirects/latest/hello-58v76y8z87lo/404.html
+++ b/apache-redirects/latest/hello-58v76y8z87lo/404.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <title>Hellomagazine</title>
+</head>
+<body>
+<div class="flex flex-col min-h-[100vh] items-center justify-center space-y-4 px-4 pb-4">
+    <div class="space-y-2 text-center">
+        <h1 class="text-4xl font-bold tracking-tighter sm:text-5xl">404: Page Not Found</h1>
+        <p class="mx-auto max-w-[600px] text-gray-500 md:text-xl/relaxed dark:text-gray-400">
+            Don't worry, you haven't broken the internet. You can find your way back by clicking the button below.
+        </p>
+    </div>
+    <a
+            class="inline-flex h-9 items-center justify-center rounded-md border border-gray-200 border-gray-200 bg-white px-4 shadow-sm text-sm font-medium transition-colors hover:bg-gray-100 hover:text-gray-900"
+            href="https://www.hellomagazine.com/"
+    >
+        Return Home
+    </a>
+</div>
+</body>
+</html>

--- a/apache-redirects/latest/httpd-vhosts.conf
+++ b/apache-redirects/latest/httpd-vhosts.conf
@@ -102,3 +102,8 @@
     DocumentRoot "/var/www/himgs"
     ServerName www.himgs.com
 </VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/hello-58v76y8z87lo"
+    ServerName 58v76y8z87lo.hellomagazine.com
+</VirtualHost>


### PR DESCRIPTION
This pull request introduces support for a new virtual host, `58v76y8z87lo.hellomagazine.com`, in the Apache configuration. The changes ensure that the new host has its own directory, content, and redirect rules, aligning it with existing host setups.

**Virtual host setup and configuration:**

* Added a new virtual host for `58v76y8z87lo.hellomagazine.com` in `httpd-vhosts.conf`, pointing to the new directory `/var/www/hello-58v76y8z87lo`.
* Updated the `Dockerfile` to create the directory, copy its contents, and ensure `index.html` is present for the new host. [[1]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R19) [[2]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R33) [[3]](diffhunk://#diff-68c6527b8547ea459b6fd5b7706a691da01334b5eaf8fecdf31ef9ead705c2b5R51)

**Redirect and error handling:**

* Added a `.htaccess` file for the new host to redirect all requests to `images.hellomagazine.com` with a 301 status.
* Added a custom `404.html` page for the new host, providing a user-friendly message and a link back to the main site.…zine.com