### PR TITLE
feat: [HZN-9548] Update suscribete.hola.com to suscripciones.hola.com

### DIFF
--- a/apache-redirects/latest/Dockerfile
+++ b/apache-redirects/latest/Dockerfile
@@ -49,5 +49,6 @@ COPY hola/* /var/www/hola/
 COPY quiosco-static/* /var/www/quiosco-static/
 COPY himgs/* /var/www/himgs/
 COPY hello-58v76y8z87lo/* /var/www/hello-58v76y8z87lo/
+COPY hola-ecommerce/* /var/www/hola-ecommerce/
 
 EXPOSE 80

--- a/apache-redirects/latest/hola-ecommerce/.htaccess
+++ b/apache-redirects/latest/hola-ecommerce/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+
+RewriteCond %{HTTP_HOST} ^suscribete\.hola\.com$ [NC]
+RewriteRule ^(.*)$ https://suscripciones.hola.com/$1 [R=301,L]

--- a/apache-redirects/latest/hola-ecommerce/index.html
+++ b/apache-redirects/latest/hola-ecommerce/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+<div class="flex flex-col min-h-[100vh] items-center justify-center space-y-4 px-4 pb-4">
+    <div class="space-y-2 text-center">
+        <h1 class="text-4xl font-bold tracking-tighter sm:text-5xl">404: Page Not Found</h1>
+        <p class="mx-auto max-w-[600px] text-gray-500 md:text-xl/relaxed dark:text-gray-400">
+            Don't worry, you haven't broken the internet. You can find your way back by clicking the button below.
+        </p>
+    </div>
+    <a
+            class="inline-flex h-9 items-center justify-center rounded-md border border-gray-200 border-gray-200 bg-white px-4 shadow-sm text-sm font-medium transition-colors hover:bg-gray-100 hover:text-gray-900"
+            href="https://suscripciones.hola.com"
+    >
+        Return Home
+    </a>
+</div>
+</body>
+</html>

--- a/apache-redirects/latest/httpd-vhosts.conf
+++ b/apache-redirects/latest/httpd-vhosts.conf
@@ -107,3 +107,8 @@
     DocumentRoot "/var/www/hello-58v76y8z87lo"
     ServerName 58v76y8z87lo.hellomagazine.com
 </VirtualHost>
+
+<VirtualHost *:80>
+    DocumentRoot "/var/www/hola-ecommerce"
+    ServerName suscribete.hola.com
+</VirtualHost>


### PR DESCRIPTION
This pull request adds support for a new virtual host for `suscribete.hola.com` in the Apache redirects configuration. It introduces a new static site directory (`hola-ecommerce`) with a custom 404 page and a redirect rule to send all traffic to `https://suscripciones.hola.com`. The most important changes are:

**New virtual host and static site setup:**

* Added a new virtual host for `suscribete.hola.com` in `httpd-vhosts.conf`, serving files from the new `hola-ecommerce` directory.
* Updated the Dockerfile to copy the contents of `hola-ecommerce` into the image.

**Redirect and error handling:**

* Created a `.htaccess` file in `hola-ecommerce` to redirect all requests from `suscribete.hola.com` to `https://suscripciones.hola.com` with a 301 status.
* Added a user-friendly `index.html` in `hola-ecommerce` that displays a 404 page with a link back to the main site.