### PR TITLE
fix: [HZN-9857] - PressReader Service fails when calls to suscribete

### DIFF
--- a/apache-redirects/latest/hola-ecommerce/.htaccess
+++ b/apache-redirects/latest/hola-ecommerce/.htaccess
@@ -1,4 +1,4 @@
 RewriteEngine On
 
 RewriteCond %{HTTP_HOST} ^suscribete\.hola\.com$ [NC]
-RewriteRule ^(.*)$ https://suscripciones.hola.com/$1 [R=301,L]
+RewriteRule ^(.*)$ https://suscripciones.hola.com/$1 [R=308,L]


### PR DESCRIPTION
This pull request updates the HTTP redirect status code in the `.htaccess` configuration for `suscribete.hola.com` to improve how permanent redirects are handled.

Redirect configuration update:

* Changed the redirect status code from `301` (Moved Permanently) to `308` (Permanent Redirect) in the `apache-redirects/latest/hola-ecommerce/.htaccess` file to ensure request methods and bodies are preserved during redirects.